### PR TITLE
Compilation fails on 32bit

### DIFF
--- a/ext/mri/scrypt_ext.c
+++ b/ext/mri/scrypt_ext.c
@@ -18,7 +18,7 @@ static VALUE sc_calibrate( VALUE self, VALUE maxmem, VALUE maxmemfrac, VALUE max
 	uint32_t r = 0;
 	uint32_t p = 0;
 
-	size_t mm = rb_num2uint( maxmem );
+	size_t mm = NUM2UINT( maxmem );
 	double mf = rb_num2dbl( maxmemfrac );
 	double mt = rb_num2dbl( maxtime );
 


### PR DESCRIPTION
The compilation of the C extension fails on 32bit machines. 

This is because rb_num2uint is only compiled on machines where the size of ints is different from the size of longs.

Use of the macro NUM2UINT fixes that.
