### PR TITLE
Fix #2 by avoiding OpenSSL namespace collisions

### DIFF
--- a/ext/mri/crypto_scrypt-ref.c
+++ b/ext/mri/crypto_scrypt-ref.c
@@ -255,7 +255,7 @@ crypto_scrypt(const uint8_t * passwd, size_t passwdlen,
 		goto err2;
 
 	/* 1: (B_0 ... B_{p-1}) <-- PBKDF2(P, S, 1, p * MFLen) */
-	PBKDF2_SHA256(passwd, passwdlen, salt, saltlen, 1, B, p * 128 * r);
+	PBKDF2_scrypt_SHA256(passwd, passwdlen, salt, saltlen, 1, B, p * 128 * r);
 
 	/* 2: for i = 0 to p - 1 do */
 	for (i = 0; i < p; i++) {
@@ -264,7 +264,7 @@ crypto_scrypt(const uint8_t * passwd, size_t passwdlen,
 	}
 
 	/* 5: DK <-- PBKDF2(P, B, 1, dkLen) */
-	PBKDF2_SHA256(passwd, passwdlen, B, p * 128 * r, 1, buf, buflen);
+	PBKDF2_scrypt_SHA256(passwd, passwdlen, B, p * 128 * r, 1, buf, buflen);
 
 	/* Free memory. */
 	free(V);

--- a/ext/mri/sha256.h
+++ b/ext/mri/sha256.h
@@ -26,37 +26,37 @@
  * $FreeBSD: src/lib/libmd/sha256.h,v 1.2 2006/01/17 15:35:56 phk Exp $
  */
 
-#ifndef _SHA256_H_
-#define _SHA256_H_
+#ifndef _scrypt_SHA256_H_
+#define _scrypt_SHA256_H_
 
 #include <sys/types.h>
 
 #include <stdint.h>
 
-typedef struct SHA256Context {
+typedef struct scrypt_SHA256Context {
 	uint32_t state[8];
 	uint32_t count[2];
 	unsigned char buf[64];
-} SHA256_CTX;
+} scrypt_SHA256_CTX;
 
-typedef struct HMAC_SHA256Context {
-	SHA256_CTX ictx;
-	SHA256_CTX octx;
-} HMAC_SHA256_CTX;
+typedef struct HMAC_scrypt_SHA256Context {
+	scrypt_SHA256_CTX ictx;
+	scrypt_SHA256_CTX octx;
+} HMAC_scrypt_SHA256_CTX;
 
-void	SHA256_Init(SHA256_CTX *);
-void	SHA256_Update(SHA256_CTX *, const void *, size_t);
-void	SHA256_Final(unsigned char [32], SHA256_CTX *);
-void	HMAC_SHA256_Init(HMAC_SHA256_CTX *, const void *, size_t);
-void	HMAC_SHA256_Update(HMAC_SHA256_CTX *, const void *, size_t);
-void	HMAC_SHA256_Final(unsigned char [32], HMAC_SHA256_CTX *);
+void	scrypt_SHA256_Init(scrypt_SHA256_CTX *);
+void	scrypt_SHA256_Update(scrypt_SHA256_CTX *, const void *, size_t);
+void	scrypt_SHA256_Final(unsigned char [32], scrypt_SHA256_CTX *);
+void	HMAC_scrypt_SHA256_Init(HMAC_scrypt_SHA256_CTX *, const void *, size_t);
+void	HMAC_scrypt_SHA256_Update(HMAC_scrypt_SHA256_CTX *, const void *, size_t);
+void	HMAC_scrypt_SHA256_Final(unsigned char [32], HMAC_scrypt_SHA256_CTX *);
 
 /**
- * PBKDF2_SHA256(passwd, passwdlen, salt, saltlen, c, buf, dkLen):
- * Compute PBKDF2(passwd, salt, c, dkLen) using HMAC-SHA256 as the PRF, and
+ * PBKDF2_scrypt_SHA256(passwd, passwdlen, salt, saltlen, c, buf, dkLen):
+ * Compute PBKDF2(passwd, salt, c, dkLen) using HMAC-scrypt_SHA256 as the PRF, and
  * write the output to buf.  The value dkLen must be at most 32 * (2^32 - 1).
  */
-void	PBKDF2_SHA256(const uint8_t *, size_t, const uint8_t *, size_t,
+void	PBKDF2_scrypt_SHA256(const uint8_t *, size_t, const uint8_t *, size_t,
     uint64_t, uint8_t *, size_t);
 
-#endif /* !_SHA256_H_ */
+#endif /* !_scrypt_SHA256_H_ */


### PR DESCRIPTION
<cperciva> Freeky: ah, that's the openssl namespace collision bug
<cperciva> Freeky: apply a s/SHA256/scrypt_SHA256/g to the scrypt code and it should work fine
* cperciva now has #define SHA256_foo libcperciva_SHA256_foo in his code
<cperciva> for precisely this reason
