### PR TITLE
take correct length of utf-8 strings

### DIFF
--- a/lib/scrypt.rb
+++ b/lib/scrypt.rb
@@ -150,7 +150,7 @@ module SCrypt
 
       FFI::MemoryPointer.new(:char, key_len) do |buffer|
         retval = SCrypt::Ext.crypto_scrypt(
-          secret, secret.length, salt, salt.length,
+          secret, secret.bytesize, salt, salt.bytesize,
           n, r, p,
           buffer, key_len
         )


### PR DESCRIPTION
# length changed to #bytesize as the later returns the correct size of bytes for an utf-8 encoded string

example: "ä".length =1 , but "ä".bytesize = 2
