### PR TITLE
Allow users to calibrate cost factors once

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Password.create takes five options which will determine the key length and salt 
 * `:max_time` specifies the maximum number of seconds the computation should take.
 * `:max_mem` specifies the maximum number of bytes the computation should take. A value of 0 specifies no upper limit. The minimum is always 1 MB.
 * `:max_memfrac` specifies the maximum memory in a fraction of available resources to use. Any value equal to 0 or greater than 0.5 will result in 0.5 being used.
+* `:cost` specifies a cost string (e.g. `'400$8$19$'`) from the `calibrate` method.  The `:max_*` options will be ignored if this option is given, or if `calibrate!` has been called.
 
 Default options will result in calculation time of approx. 200 ms with 1 MB memory use.
 
@@ -57,6 +58,12 @@ salt = SCrypt::Engine.generate_salt
 
 SCrypt::Engine.hash_secret "my grand secret", salt
 # => "400$8$26$b62e0f787a5fc373$0399ccd4fa26642d92741b17c366b7f6bd12ccea5214987af445d2bed97bc6a2"
+
+SCrypt::Engine.calibrate!(max_mem: 16 * 1024 * 1024)
+# => "4000$8$4$"
+
+SCrypt::Engine.generate_salt
+# => "4000$8$4$c6d101522d3cb045"
 ```
 
 ## Usage in Rails (and the like)

--- a/spec/scrypt/engine_spec.rb
+++ b/spec/scrypt/engine_spec.rb
@@ -16,6 +16,15 @@ describe "Generating SCrypt salts" do
   it "should produce random data" do
     SCrypt::Engine.generate_salt.should_not equal(SCrypt::Engine.generate_salt)
   end
+
+  it "should used the saved cost factor" do
+    # Verify cost is different before saving
+    cost = SCrypt::Engine.calibrate(:max_time => 0.01)
+    SCrypt::Engine.generate_salt(:max_time => 30, :max_mem => 64*1024*1024).should_not start_with(cost)
+
+    cost = SCrypt::Engine.calibrate!(:max_time => 0.01)
+    SCrypt::Engine.generate_salt(:max_time => 30, :max_mem => 64*1024*1024).should start_with(cost)
+  end
 end
 
 


### PR DESCRIPTION
This pull request adds `SCrypt::Engine.calibrate!`, which saves a cost string
for use by `SCrypt::Engine.generate_salt`.  With this change a developer can
calibrate SCrypt once (e.g. in a Rails initializer for Rails apps), preventing
changes in system load from affecting the calibration of each digest.

This can serve as a workaround for https://github.com/pbhogan/scrypt/issues/39
