### PR TITLE
Use more secure default parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ password == "a paltry guess"  # => false
 Password.create takes five options which will determine the key length and salt size, as well as the cost limits of the computation:
 
 * `:key_len` specifies the length in bytes of the key you want to generate. The default is 32 bytes (256 bits). Minimum is 16 bytes (128 bits). Maximum is 512 bytes (4096 bits).
-* `:salt_size` specifies the size in bytes of the random salt you want to generate. The default and minimum is 8 bytes (64 bits). Maximum is 32 bytes (256 bits).
+* `:salt_size` specifies the size in bytes of the random salt you want to generate. The default and maximum is 32 bytes (256 bits). Minimum is 8 bytes (64 bits).
 * `:max_time` specifies the maximum number of seconds the computation should take.
 * `:max_mem` specifies the maximum number of bytes the computation should take. A value of 0 specifies no upper limit. The minimum is always 1 MB.
 * `:max_memfrac` specifies the maximum memory in a fraction of available resources to use. Any value equal to 0 or greater than 0.5 will result in 0.5 being used.
 * `:cost` specifies a cost string (e.g. `'400$8$19$'`) from the `calibrate` method.  The `:max_*` options will be ignored if this option is given, or if `calibrate!` has been called.
 
-Default options will result in calculation time of approx. 200 ms with 1 MB memory use.
+Default options will result in calculation time of approx. 200 ms with 16 MB memory use.
 
 ## Other things you can do
 

--- a/lib/scrypt.rb
+++ b/lib/scrypt.rb
@@ -24,8 +24,8 @@ module SCrypt
   class Engine
     DEFAULTS = {
       :key_len     => 32,
-      :salt_size   => 8,
-      :max_mem     => 1024 * 1024,
+      :salt_size   => 32,
+      :max_mem     => 16 * 1024 * 1024,
       :max_memfrac => 0.5,
       :max_time    => 0.2,
       :cost        => nil


### PR DESCRIPTION
Increase max_mem from 1MB to 16MB, and salt_len from 8 to 32 bytes.

Fixes #25 