### PR TITLE
Add mman.h for Windows compatibility

### DIFF
--- a/ext/scrypt/crypto_scrypt.c
+++ b/ext/scrypt/crypto_scrypt.c
@@ -29,13 +29,13 @@
 /* #include "bsdtar_platform.h" */
 
 #include <sys/types.h>
-#include <sys/mman.h>
 
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "mman.h"
 #include "cpusupport.h"
 #include "sha256.h"
 //#include "warnp.h"

--- a/ext/scrypt/mman.h
+++ b/ext/scrypt/mman.h
@@ -1,0 +1,55 @@
+/*
+ * sys/mman.h
+ * mman-win32
+ */
+
+#ifndef _SYS_MMAN_H_
+#define _SYS_MMAN_H_
+
+#ifndef _WIN32_WINNT		// Allow use of features specific to Windows XP or later.                   
+#define _WIN32_WINNT 0x0501	// Change this to the appropriate value to target other versions of Windows.
+#endif						
+
+/* All the headers include this file. */
+#ifndef _MSC_VER
+#include <_mingw.h>
+#endif
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PROT_NONE       0
+#define PROT_READ       1
+#define PROT_WRITE      2
+#define PROT_EXEC       4
+
+#define MAP_FILE        0
+#define MAP_SHARED      1
+#define MAP_PRIVATE     2
+#define MAP_TYPE        0xf
+#define MAP_FIXED       0x10
+#define MAP_ANONYMOUS   0x20
+#define MAP_ANON        MAP_ANONYMOUS
+
+#define MAP_FAILED      ((void *)-1)
+
+/* Flags for msync. */
+#define MS_ASYNC        1
+#define MS_SYNC         2
+#define MS_INVALIDATE   4
+
+void*   mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off);
+int     munmap(void *addr, size_t len);
+int     _mprotect(void *addr, size_t len, int prot);
+int     msync(void *addr, size_t len, int flags);
+int     mlock(const void *addr, size_t len);
+int     munlock(const void *addr, size_t len);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /*  _SYS_MMAN_H_ */


### PR DESCRIPTION
When I do 'gem install scrypt' on Windows 7, there is an error:

```
ERROR: Error installing scrypt:
ERROR: Failed to build gem native extension.

current directory: C:/Ruby/lib/ruby/gems/2.3.0/gems/scrypt-3.0.0/ext/scrypt
C:/Ruby/bin/ruby.exe -rubygems C:/Ruby/lib/ruby/gems/2.3.0/gems/rake-11.2.2/exe/rake RUBYARCHDIR=C:/Ruby/lib/ruby/gems/2.3.0/extensions/x86-mingw32/2.3.0/scrypt-3.0.0 RUBYLIBDIR=C:/Ruby/lib/ruby/gems/2.3.0/extensions/x86-mingw32/2.3.0/scrypt-3.0.0
mkdir -p i386-windows
gcc -fexceptions -O -fno-omit-frame-pointer -fno-strict-aliasing -Wall -std=c99 -msse -msse2 -D_GNU_SOURCE=1 -fPIC  -o i386-windows/crypto_scrypt.o -c ./crypto_scrypt.c
./crypto_scrypt.c:1:0: warning: -fPIC ignored for target (all code is position independent) [enabled by default]
./crypto_scrypt.c:32:22: fatal error: sys/mman.h: No such file or directory compilation terminated.
rake aborted!
Command failed with status (1): [gcc -fexceptions -O -fno-omit-frame-pointe...]

Tasks: TOP => default => i386-windows/scrypt_ext.dll => i386-windows/crypto_scrypt.o
(See full trace by running task with --trace)

rake failed, exit code 1

Gem files will remain installed in C:/Ruby/lib/ruby/gems/2.3.0/gems/scrypt-3.0.0 for inspection.
Results logged to C:/Ruby/lib/ruby/gems/2.3.0/extensions/x86-mingw32/2.3.0/scrypt-3.0.0/gem_make.out
```

So, I added a `mman.h` to fix (source: https://github.com/witwall/mman-win32).

Note: actually there is another error on Windows, with `ffi` gem (`LoadError: cannot load such file -- ffi_c`).  You can fix it by `gem uninstall ffi -I && gem install ffi --platform=ruby`.