### PR TITLE
Improve last example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ SCrypt::Engine.generate_salt
 
 ```ruby
 # store it safely in the user model
-user.update_attribute(:password, @password)
+user.update_attribute(:password, SCrypt::Password.create("my grand secret"))
 
 # read it back later
 user.reload!


### PR DESCRIPTION
Do not use `@password` which is not defined anywhere.  Instead scrypt the password that will be checked later on.  Maybe this will also help to distinguish between `#new` and `#create` which may be confusing to non-bcrypt-ruby users.