### PR TITLE
Fixes #59 and #65 Building on Archlinux

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ namespace "ffi-compiler" do
     t.cflags << "-Wall -std=c99"
     t.cflags << "-msse -msse2" if t.platform.arch.include? "86"
     t.cflags << "-D_GNU_SOURCE=1" if RbConfig::CONFIG["host_os"].downcase =~ /mingw/
-    t.cflags << "-D__need_timespec" if RbConfig::CONFIG['host_os'].downcase =~ /linux/
+    t.cflags << "-D_POSIX_C_SOURCE=199309L" if RbConfig::CONFIG['host_os'].downcase =~ /linux/
     t.cflags << "-arch x86_64 -arch i386" if t.platform.mac?
     t.ldflags << "-arch x86_64 -arch i386" if t.platform.mac?
 

--- a/ext/scrypt/Rakefile
+++ b/ext/scrypt/Rakefile
@@ -4,7 +4,7 @@ FFI::Compiler::CompileTask.new('scrypt_ext') do |t|
   t.cflags << "-Wall -std=c99"
   t.cflags << "-msse -msse2" if t.platform.arch.include? "86"
   t.cflags << "-D_GNU_SOURCE=1" if RbConfig::CONFIG["host_os"].downcase =~ /mingw/
-  t.cflags << "-D__need_timespec" if RbConfig::CONFIG['host_os'].downcase =~ /linux/
+  t.cflags << "-D_POSIX_C_SOURCE=199309L" if RbConfig::CONFIG['host_os'].downcase =~ /linux/
   t.cflags << "-arch x86_64 -arch i386" if t.platform.mac?
   t.ldflags << "-arch x86_64 -arch i386" if t.platform.mac?
   t.export '../../lib/scrypt/scrypt_ext.rb'


### PR DESCRIPTION
I could get this compiling and tests passing on my system (Archlinux, GCC 6.3.1) with -std=c99 by replacing -D__need_timespec with -D_POSIX_C_SOURCE=199309L which I found referenced [here](https://gcc.gnu.org/ml/gcc-help/2004-02/msg00098.html).

I also tested on Debian with GCC 4.9.2, in that environment it compiles with and without the flag.