### PR TITLE
Make `rake` development dependency not runtime

### DIFF
--- a/scrypt.gemspec
+++ b/scrypt.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   EOF
 
   s.add_dependency 'ffi-compiler', '>= 1.0', '< 2.0'
-  s.add_dependency 'rake', '>= 9', '< 12'
+  s.add_development_dependency 'rake', '>= 9', '< 12'
   s.add_development_dependency 'rspec', '>= 3', '< 4'
   s.add_development_dependency 'rdoc', '>= 4', '< 5'
   s.add_development_dependency 'awesome_print', '>= 1', '< 2'


### PR DESCRIPTION
Rake is used by `scrypt` during development only.