### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/scrypt.gemspec
+++ b/scrypt.gemspec
@@ -42,8 +42,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rubocop-performance', '>= 1.5.0', '< 1.6.0'
   end
 
-  s.rubyforge_project = 'scrypt'
-
   s.extensions = ['ext/scrypt/Rakefile']
 
   s.files = %w[Rakefile scrypt.gemspec README.md COPYING] + Dir.glob('{lib,spec,autotest}/**/*')


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436