### PR TITLE
Use newer _POSIX_C_SOURCE to work with GCC 14.0+

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ namespace 'ffi-compiler' do
     t.cflags << '-Wall -std=c99'
     t.cflags << '-msse -msse2' if t.platform.arch.include? '86'
     t.cflags << '-D_GNU_SOURCE=1' if RbConfig::CONFIG['host_os'].downcase =~ /mingw/
-    t.cflags << '-D_POSIX_C_SOURCE=199309L' if RbConfig::CONFIG['host_os'].downcase =~ /linux/
+    t.cflags << '-D_POSIX_C_SOURCE=200809L' if RbConfig::CONFIG['host_os'].downcase =~ /linux/
 
     if 1.size == 4 && target_cpu =~ /i386|x86_32/ && t.platform.mac?
       t.cflags << '-arch i386'

--- a/ext/scrypt/Rakefile
+++ b/ext/scrypt/Rakefile
@@ -6,7 +6,7 @@ FFI::Compiler::CompileTask.new('scrypt_ext') do |t|
   t.cflags << '-Wall -std=c99'
   t.cflags << '-msse -msse2' if t.platform.arch.include? '86'
   t.cflags << '-D_GNU_SOURCE=1' if RbConfig::CONFIG['host_os'].downcase =~ /mingw/
-  t.cflags << '-D_POSIX_C_SOURCE=199309L' if RbConfig::CONFIG['host_os'].downcase =~ /linux/
+  t.cflags << '-D_POSIX_C_SOURCE=200809L' if RbConfig::CONFIG['host_os'].downcase =~ /linux/
 
   if 1.size == 4 && target_cpu =~ /i386|x86_32/ && t.platform.mac?
     t.cflags << '-arch i386'


### PR DESCRIPTION
Since GCC 14 makes `-Wimplicit-function-declaration` and `-Wint-conversion` manifest as errors, we need to actually include newer POSIX version that actually exposes 'strdup' as function, instead of relying it getting included implicitly. Otherwise compiling scrypt with GCC 14.0+ fails.

Without this change we can see warnings(on GCC < 14)/errors (on GCC 14+) as part of compilation:
```
ext/scrypt/warnp.c: In function ‘warnp_setprogname’:
ext/scrypt/warnp.c:39:16: warning: implicit declaration of function ‘strdup’; did you mean ‘strcmp’? [-Wimplicit-function-declaration]
   39 |         name = strdup(p);
      |                ^~~~~~
      |                strcmp
ext/scrypt/warnp.c:39:14: warning: assignment to ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
   39 |         name = strdup(p);
      |              ^
```

With newer POSIX version, just compiles no errors:
```
gcc -fexceptions -O -fno-omit-frame-pointer -fno-strict-aliasing -Wall -std\=c99 -msse -msse2 -D_POSIX_C_SOURCE\=200809L -fPIC -o ext/scrypt/x86_64-linux/warnp.o -c ext/scrypt/warnp.c
```

Resources:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96284
- https://stackoverflow.com/a/26285540/925315