### PR TITLE
Make project work with Ruby 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,2 @@
 source "http://rubygems.org"
 gemspec
-
-# Require the rubinius standard library for tests
-gem "rubysl", :platform => :rbx

--- a/scrypt.gemspec
+++ b/scrypt.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'ffi-compiler', '>= 1.0', '< 2.0'
   s.add_development_dependency 'awesome_print', '>= 1', '< 2'
-  s.add_development_dependency 'rake', '>= 9', '< 13'
+  s.add_development_dependency 'rake', '>= 9', '< 14'
   s.add_development_dependency 'rdoc', '>= 4', '< 5'
   s.add_development_dependency 'rspec', '>= 3', '< 4'
 

--- a/spec/scrypt/engine_spec.rb
+++ b/spec/scrypt/engine_spec.rb
@@ -49,13 +49,13 @@ describe 'Generating SCrypt hashes' do
   end
 
   it 'should raise an InvalidSalt error if the salt is invalid' do
-    expect(-> { SCrypt::Engine.hash_secret(@password, 'nino') }).to raise_error(SCrypt::Errors::InvalidSalt)
+    expect { SCrypt::Engine.hash_secret(@password, 'nino') }.to raise_error(SCrypt::Errors::InvalidSalt)
   end
 
   it 'should raise an InvalidSecret error if the secret is invalid' do
-    expect(-> { SCrypt::Engine.hash_secret(MyInvalidSecret.new, @salt) }).to raise_error(SCrypt::Errors::InvalidSecret)
-    expect(-> { SCrypt::Engine.hash_secret(nil, @salt) }).to_not raise_error
-    expect(-> { SCrypt::Engine.hash_secret(false, @salt) }).to_not raise_error
+    expect { SCrypt::Engine.hash_secret(MyInvalidSecret.new, @salt) }.to raise_error(SCrypt::Errors::InvalidSecret)
+    expect { SCrypt::Engine.hash_secret(nil, @salt) }.to_not raise_error
+    expect { SCrypt::Engine.hash_secret(false, @salt) }.to_not raise_error
   end
 
   it 'should call #to_s on the secret and use the return value as the actual secret data' do

--- a/spec/scrypt/password_spec.rb
+++ b/spec/scrypt/password_spec.rb
@@ -42,7 +42,7 @@ describe 'Reading a hashed password' do
   end
 
   it 'should raise an InvalidHashError when given an invalid hash' do
-    expect(-> { SCrypt::Password.new('not a valid hash') }).to raise_error(SCrypt::Errors::InvalidHash)
+    expect { SCrypt::Password.new('not a valid hash') }.to raise_error(SCrypt::Errors::InvalidHash)
   end
 end
 


### PR DESCRIPTION
During working with https://github.com/pbhogan/scrypt/pull/87 I noticed few things that seemed small enough things to fix:
- I needed to install Ruby 2.7. This was dead dependency in Gemfile
- some warnings from RSpec
- project depended on old Rake. Updated it and it worked nicely.

Rubocop can be updated as well, but this is effort on it's own and I didn't want to dwell into that, since this requires more maintainers touch.

