### PR TITLE
fix: build failures with `-std=c99`

### DIFF
--- a/ext/scrypt/warnp.c
+++ b/ext/scrypt/warnp.c
@@ -41,7 +41,8 @@ warnp_setprogname(const char * progname)
 		/* No cleanup handler needs to be registered on failure. */
 		return;
 	}
-	strcpy(name, p);
+	strncpy(name, p, strlen(p) + 1);
+	name[strlen(p)] = '\0';  /* Ensure null termination */
 
 	/* If we haven't already done so, register our exit handler. */
 	if (initialized == 0) {

--- a/ext/scrypt/warnp.c
+++ b/ext/scrypt/warnp.c
@@ -36,7 +36,12 @@ warnp_setprogname(const char * progname)
 			p = progname + 1;
 
 	/* Copy the name string. */
-	name = strdup(p);
+	name = malloc(strlen(p) + 1);
+	if (name == NULL) {
+		/* No cleanup handler needs to be registered on failure. */
+		return;
+	}
+	strcpy(name, p);
 
 	/* If we haven't already done so, register our exit handler. */
 	if (initialized == 0) {


### PR DESCRIPTION
`strdup()` is not part of C99; replace it with `malloc()` and `strcpy()`.

Fixes #92.